### PR TITLE
Deprecate Atlas provider, and use the "Atlas" name to avoid future confusion

### DIFF
--- a/website/docs/d/artifact.html.markdown
+++ b/website/docs/d/artifact.html.markdown
@@ -1,9 +1,9 @@
 ---
 layout: "terraform-enterprise"
-page_title: "Terraform Enterprise: atlas_artifact"
+page_title: "Atlas: atlas_artifact"
 sidebar_current: "docs-terraform-enterprise-data-artifact"
 description: |-
-  Provides a data source to deployment artifacts managed by Terraform Enterprise. This can
+  Provides a data source to deployment artifacts managed by Atlas. This can
   be used to dynamically configure instantiation and provisioning
   of resources.
 ---
@@ -11,8 +11,10 @@ description: |-
 # atlas_artifact
 
 Provides a [Data Source](/docs/configuration/data-sources.html) to access to deployment
-artifacts managed by Terraform Enterprise. This can be used to dynamically configure instantiation
+artifacts managed by Atlas. This can be used to dynamically configure instantiation
 and provisioning of resources.
+
+~> **This provider is deprecated,** and the service it interacts with has been discontinued.
 
 ## Example Usage
 
@@ -45,7 +47,7 @@ resource "aws_instance" "app" {
 
 The following arguments are supported:
 
-* `name` - (Required) Name of the artifact in Terraform Enterprise. This is given
+* `name` - (Required) Name of the artifact in Atlas. This is given
   in slug format like "organization/artifact".
 
 * `type` - (Required) The type of artifact to query for.
@@ -56,7 +58,7 @@ The following arguments are supported:
   matching artifact in any build, or a specific number to pin to that
   build. If `build` and `version` are unspecified, `version` will default
   to "latest". Cannot be specified with `version`. Note: `build` is only
-  present if Terraform Enterprise builds the image.
+  present if Atlas builds the image.
 
 * `version` - (Optional)  The version of the artifact to filter on. This can
   be "latest", to match against the latest version, "any" to find a matching artifact
@@ -85,4 +87,4 @@ The following attributes are exported:
   to replace any characters that are invalid in a resource name with a hyphen.
   For example, the "region.us-east-1" key will become "region-us-east-1".
 * `version_real` - The matching version of the artifact
-* `slug` - The artifact slug in Terraform Enterprise
+* `slug` - The artifact slug in Atlas

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -1,32 +1,27 @@
 ---
 layout: "terraform-enterprise"
-page_title: "Provider: Terraform Enterprise"
+page_title: "Provider: Atlas"
 sidebar_current: "docs-terraform-enterprise-index"
 description: |-
-  The Terraform Enterprise provider is used to interact with configuration,
-  artifacts, and metadata managed by the Terraform Enterprise service.
+  The Atlas provider was used to interact with configuration,
+  artifacts, and metadata managed by the discontinued Atlas service.
 ---
 
-# Terraform Enterprise Provider
+# Atlas Provider
 
-The Terraform Enterprise provider is used to interact with resources,
-configuration, artifacts, and metadata managed by
-[Terraform Enterprise](https://www.terraform.io/docs/providers/index.html).
+~> **This provider is deprecated,** and the service it interacts with has been discontinued.
+
+The Atlas provider was used to interact with objects in Atlas's artifact registry, which were usually machine images built with Packer. In 2018, the Atlas suite was discontinued. It is replaced by [Terraform Enterprise](https://www.terraform.io/docs/enterprise/index.html), which focuses on the core Terraform workflow and does not include an artifact registry. For more information, see [Differences Between Current and Legacy Terraform Enterprise](https://www.terraform.io/docs/enterprise/upgrade/differences.html).
+
 The provider needs to be configured with the proper credentials before it can
 be used.
 
 Use the navigation to the left to read about the available resources.
 
-~> **Why is this called "atlas"?** Atlas was previously a commercial offering
-from HashiCorp that included a full suite of enterprise products. The products
-have since been broken apart into their individual products, like **Terraform
-Enterprise**. While this transition is in progress, you may see references to
-"atlas" in the documentation. We apologize for the inconvenience.
-
 ## Example Usage
 
 ```hcl
-# Configure the Terraform Enterprise provider
+# Configure the Atlas provider
 provider "atlas" {
   token = "${var.atlas_token}"
 }
@@ -41,9 +36,9 @@ data "atlas_artifact" "web" {
 
 The following arguments are supported:
 
-* `address` - (Optional) Terraform Enterprise server endpoint. Defaults to
-  public Terraform Enterprise. This is only required when using an on-premise
-  deployment of Terraform Enterprise. This can also be specified with the
+* `address` - (Optional) Atlas server endpoint. Defaults to
+  public Atlas. This is only required when using an on-premise
+  deployment of Atlas. This can also be specified with the
   `ATLAS_ADDRESS` shell environment variable.
 
 * `token` - (Required) API token. This can also be specified with the

--- a/website/docs/r/artifact.html.markdown
+++ b/website/docs/r/artifact.html.markdown
@@ -1,19 +1,20 @@
 ---
 layout: "terraform-enterprise"
-page_title: "Terraform Enterprise: atlas_artifact"
+page_title: "Atlas: atlas_artifact"
 sidebar_current: "docs-terraform-enterprise-resource-artifact"
 description: |-
-  Provides access to deployment artifacts managed by Terraform Enterprise. This
+  Provides access to deployment artifacts managed by Atlas. This
   can be used to dynamically configure instantiation and provisioning of
   resources.
 ---
 
 # atlas_artifact
 
-Provides access to deployment artifacts managed by Terraform Enterprise. This
+Provides access to deployment artifacts managed by Atlas. This
 can be used to dynamically configure instantiation and provisioning of
 resources.
 
+~> **This provider is deprecated,** and the service it interacts with has been discontinued.
 
 ~> **This resource is deprecated!** Please use the
 [Artifact Data Source](/docs/providers/terraform-enterprise/d/artifact.html)
@@ -49,7 +50,7 @@ resource "aws_instance" "app" {
 
 The following arguments are supported:
 
-* `name` - (Required) Name of the artifact in Terraform Enterprise. This is given
+* `name` - (Required) Name of the artifact in Atlas. This is given
   in slug format like "organization/artifact".
 
 * `type` - (Required) The type of artifact to query for.
@@ -60,7 +61,7 @@ The following arguments are supported:
   matching artifact in any build, or a specific number to pin to that
   build. If `build` and `version` are unspecified, `version` will default
   to "latest". Cannot be specified with `version`. Note: `build` is only
-  present if Terraform Enterprise builds the image.
+  present if Atlas builds the image.
 
 * `version` - (Optional)  The version of the artifact to filter on. This can
   be "latest", to match against the latest version, "any" to find a matching artifact
@@ -89,4 +90,4 @@ The following attributes are exported:
   to replace any characters that are invalid in a resource name with a hyphen.
   For example, the "region.us-east-1" key will become "region-us-east-1".
 * `version_real` - The matching version of the artifact
-* `slug` - The artifact slug in Terraform Enterprise
+* `slug` - The artifact slug in Atlas

--- a/website/terraform-enterprise.erb
+++ b/website/terraform-enterprise.erb
@@ -6,7 +6,7 @@
       </li>
 
       <li<%= sidebar_current("docs-terraform-enterprise-index") %>>
-        <a class="back" href="/docs/providers/terraform-enterprise/index.html">Terraform Enterprise Provider</a>
+        <a class="back" href="/docs/providers/terraform-enterprise/index.html">Atlas Provider</a>
       </li>
 
       <h4>Data Sources</h4>


### PR DESCRIPTION
This provider was only used to read data from the artifact registry, which we
did not recreate in the new Terraform Enterprise. For most users, there's
nothing for it to talk to anymore, since the remaining Atlas code has stopped
running Packer builds and serving artifacts.

In many places in the docs, we changed "Atlas" to "Terraform Enterprise," since
Terraform was the biggest part of Atlas. However, this provider is one of the
few cases where the name update doesn't make sense: it only relates to a
non-Terraform part of the old Atlas suite. Since there will likely be a real
Terraform Enterprise provider in the future, we should go back to referring to
this provider by its old name. (This commit doesn't change the URLs yet; we can
move the files in a future edit.)